### PR TITLE
Update CachePage.php

### DIFF
--- a/src/Middleware/CachePage.php
+++ b/src/Middleware/CachePage.php
@@ -30,7 +30,7 @@ class CachePage
 				Cache::flush();
 		}
 		
-		$key = urlencode($request->url());
+		$key = urlencode($request->fullUrl());
 		
 		if ($keyBy)
 		{


### PR DESCRIPTION
To handle the cache issue url with pagination and parameters

Pagination: https://example.com?page=2
Page can have the value 1,2,3,4,5 etc.
Filters: https://example.com/brand/list?price=2500to4000&brand=samsung
price value is also changeable same is brand
So in this case the middleware will show same cache response for all these page. 
with `url` and with `fullUrl` it will consider the parameters too. so the issue be resolve.